### PR TITLE
Updating directions for running build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ sudo python3 setup.py install
 python3 -m revbayes_kernel.install
 ```
 
-The current version of `revbayes_kernel` calls the RevBayes executable named `rb-jupyter`. Support to compile `rb-jupyter` with the command `./projects/cmake/build.sh -jupyter true` was added to the development branch of the main [RevBayes](https://github.com/revbayes/revbayes) repository in commit [6028eb2](https://github.com/revbayes/revbayes/commit/6028eb2925e2910a839e98060768401843a87362).
+The current version of `revbayes_kernel` calls the RevBayes executable named `rb-jupyter`. Support to compile `rb-jupyter` with the command `./build.sh -jupyter true` was added to the development branch of the main [RevBayes](https://github.com/revbayes/revbayes) repository in commit [6028eb2](https://github.com/revbayes/revbayes/commit/6028eb2925e2910a839e98060768401843a87362). To find `build.sh`, first change your working directory `cd <revbayes_path>/projects/cmake/`.
 
 The `rb-jupyter` binary must be found using the `which` command or be located using the environment variable, `REVBAYES_JUPYTER_EXECUTABLE`.
 


### PR DESCRIPTION
build.sh needs to be run locally from within the cmake directory in order to run other scripts.